### PR TITLE
Fix CG mapping; Add mapping test

### DIFF
--- a/tests/data/test_utils/test_mapping/CG_weights_ala2.npy
+++ b/tests/data/test_utils/test_mapping/CG_weights_ala2.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7e92b6ccee1e4f926cdc6aae6a3625fa87a25b2b724d888c7693dea30fbb800
+size 1008

--- a/tests/data/test_utils/test_mapping/forces_ala2_AT.npy
+++ b/tests/data/test_utils/test_mapping/forces_ala2_AT.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b05bbd540fa21dcc881e80d71f073b11e566b82fbc49899fcc18849f4dfaa41
+size 264128

--- a/tests/data/test_utils/test_mapping/forces_ala2_CG.npy
+++ b/tests/data/test_utils/test_mapping/forces_ala2_CG.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f8c9228e3fb16ae458dbbea2af8e47fc20db8c5ccb4b01c3132f34e9aabd049
+size 120128

--- a/tests/data/test_utils/test_mapping/positions_ala2_AT.npy
+++ b/tests/data/test_utils/test_mapping/positions_ala2_AT.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95bce0ba937718604ba9d0b109d1e56acf7330c7ff71532ec843ed22ae31fdf9
+size 264128

--- a/tests/data/test_utils/test_mapping/positions_ala2_CG.npy
+++ b/tests/data/test_utils/test_mapping/positions_ala2_CG.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3e48051ddaf68112b1880a088627e3285df0f74a2103504f086db0b99e4e015
+size 120128

--- a/tests/test_utils/test_mapping.py
+++ b/tests/test_utils/test_mapping.py
@@ -1,0 +1,91 @@
+# Copyright 2023 Multiscale Modeling of Fluid Materials, TU Munich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License and limitations under the License.
+
+import jax.numpy as jnp
+from jax_md import space
+from chemtrain.data import preprocessing
+from pathlib import Path
+import pytest
+
+class TestMappingAla2:
+    @pytest.fixture
+    def setup_problem(self, datafiles):
+        # Directory containing test mapping data for alanine dipeptide
+        data_dir = Path(datafiles)
+        
+        # Load all-atom and coarse-grained data
+        Ala2_AT_F = jnp.load(str(data_dir / 'forces_ala2_AT.npy'))
+        Ala2_AT_R = jnp.load(str(data_dir / 'positions_ala2_AT.npy'))
+        Ala2_CG_F = jnp.load(str(data_dir / 'forces_ala2_CG.npy'))
+        Ala2_CG_R = jnp.load(str(data_dir / 'positions_ala2_CG.npy'))
+        weights = jnp.load(str(data_dir / 'CG_weights_ala2.npy'))
+        
+        # Define periodic box
+        box = jnp.identity(3) * 6
+        displacement_fn, shift_fn = space.periodic_general(
+            box=box, fractional_coordinates=False
+        )
+        
+        return {
+            'AT_F': Ala2_AT_F,
+            'AT_R': Ala2_AT_R,
+            'CG_F': Ala2_CG_F,
+            'CG_R': Ala2_CG_R,
+            'weights': weights,
+            'displacement_fn': displacement_fn,
+            'shift_fn': shift_fn
+        }
+
+    @pytest.mark.test_mapping_combined
+    def test_map_ala2(self, setup_problem):
+        # Get data from setup
+        data = setup_problem
+        
+        # Map dataset: positions and forces
+        mapped_R, mapped_F = preprocessing.map_dataset(
+            data['AT_R'],
+            data['displacement_fn'],
+            data['shift_fn'],
+            data['weights'],
+            data['weights'],
+            data['AT_F'],
+        )
+
+        assert mapped_R.shape == data['CG_R'].shape, \
+            f"Mapped positions shape {mapped_R.shape} does not match expected {data['CG_R'].shape}"
+        assert mapped_F.shape == data['CG_F'].shape, \
+            f"Mapped forces shape {mapped_F.shape} does not match expected {data['CG_F'].shape}"
+
+        assert jnp.allclose(mapped_R, data['CG_R'], rtol=1e-3, atol=1e-3), \
+            "Mapped positions not close to expected CG positions"
+        assert jnp.allclose(mapped_F, data['CG_F'], rtol=1e-3, atol=1e-3), \
+            "Mapped forces not close to expected CG forces"
+            
+    @pytest.mark.test_mapping_positions
+    def test_map_ala2_positions(self, setup_problem):
+        # Get data from setup
+        data = setup_problem
+        
+        # Map dataset: positions only
+        mapped_R = preprocessing.map_dataset(
+            data['AT_R'],
+            data['displacement_fn'],
+            data['shift_fn'],
+            data['weights'],
+        )
+
+        assert mapped_R.shape == data['CG_R'].shape, \
+            f"Mapped positions shape {mapped_R.shape} does not match expected {data['CG_R'].shape}"
+
+        assert jnp.allclose(mapped_R, data['CG_R'], rtol=1e-3, atol=1e-3), \
+            "Mapped positions not close to expected CG positions"
+            
+    


### PR DESCRIPTION
- Fixes `map_dataset` function: previous version fails in case two parts of one CG bead span across the middle of the box. The new version picks a reference atom for every bead, avoiding this issue. 
- Added mapping test for alanine dipeptide in `tests/test_mapping.py.` The test loads an alanine dipeptide system and verifies that mapping yields identical bead positions and forces. The coarse-grained version is obtained by merging hydrogen atoms with corresponding heavy atoms: 
![image](https://github.com/user-attachments/assets/36353b46-ef2c-49e9-9fd6-3adf492156ad)
